### PR TITLE
Fix main field (index.glsl → trace.glsl)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "glsl-ruler",
   "version": "1.0.0",
   "description": "GLSL SDF function for generating a sphere.",
-  "main": "index.glsl",
+  "main": "trace.glsl",
   "license": "MIT",
   "scripts": {
     "start": "beefy demo.js:bundle.js -- -t glslify",


### PR DESCRIPTION
`"main": "index.glsl"` points at a file that doesn't exist in the repo or tarball (only `color.glsl` and `trace.glsl` ship), so `require('glsl-ruler')` throws `MODULE_NOT_FOUND`. The README documents `trace.glsl` as the primary entry, so point `main` there. Subpath usage (`glsl-ruler/trace`, `glsl-ruler/color`) was already fine.

Note (not changed here): the `description` field still reads "GLSL SDF function for generating a sphere", which is unrelated to this raytraced-SDF ruler — worth correcting separately.