### PR TITLE
Fix demo link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ his [example implementation on Shadertoy](https://www.shadertoy.com/view/XlB3DV)
 
 [![](http://i.imgur.com/ECqABqF.gif)](http://stack.gl/glsl-ruler/)
 
-**[view demo](http://stack.gl/glsl-ruler/)**
+**[view demo](https://glslify.github.io/glsl-ruler/)**
 
 ## Usage
 


### PR DESCRIPTION
Updated demo link to point to the new URL since stack.gl doesn't seem to route to github pages for the repo.